### PR TITLE
Assr 35 visualizing продолжение

### DIFF
--- a/AssrWeb/ProcessingApp/forms.py
+++ b/AssrWeb/ProcessingApp/forms.py
@@ -8,7 +8,7 @@ class Processing_Form(ModelForm):
 
     class Meta:
         model = Processing_model
-        fields = ('dataset', 'model', 'parameters')
+        fields = ('name', 'dataset', 'model', 'parameters')
         widgets = {
             'parameters': HiddenInput()
         }

--- a/AssrWeb/ProcessingApp/models/processing_model.py
+++ b/AssrWeb/ProcessingApp/models/processing_model.py
@@ -19,19 +19,24 @@ class Processing_model(models.Model):
         Text_class = 1, "Оценка целого текста (пример: эмоциональный окрас)"
         Token_class = 2, "Оценка отдельного слова (пример: NER)"
 
+    name = models.CharField(
+        null=True,
+        max_length=256,
+        verbose_name="Имя процесса"  # User given name of processing task
+    )
     dataset = models.ForeignKey(
         DatasetFile,
         on_delete=models.CASCADE,
-        db_column='dataset_id' # Explicit column name for integration 
+        db_column='dataset_id'  # Explicit column name for integration
     )
     model = models.CharField(
         max_length=256,
         verbose_name='Имя модели обработки',
-        db_column='model_name' # Explicit column name for integration 
+        db_column='model_name'  # Explicit column name for integration
     )
     parameters = models.JSONField(
         verbose_name='Опциональные параметры модели',
-        db_column='extra_parameters', # Explicit column name for integration 
+        db_column='extra_parameters',  # Explicit column name for integration
         blank=True,
         null=True
     )
@@ -40,7 +45,7 @@ class Processing_model(models.Model):
         choices=Status.choices,
         default=Status.Cre,
         verbose_name='Статус',
-        db_column='status', # Explicit column name for integration
+        db_column='status',  # Explicit column name for integration
         blank=True
     )
     creationTime = models.DateTimeField(
@@ -50,7 +55,7 @@ class Processing_model(models.Model):
     task = models.IntegerField(
         choices=Task.choices,
         verbose_name='Задача модели',
-        db_column='task', # Explicit column name for integration
+        db_column='task',  # Explicit column name for integration
         blank=True,
         null=True
     )

--- a/AssrWeb/ProcessingApp/views/list_result_view.py
+++ b/AssrWeb/ProcessingApp/views/list_result_view.py
@@ -5,7 +5,15 @@ from ProcessingApp.models import Processing_model
 
 class List_Result_View(ListView):
     model = Processing_model
-    fields = ('pk', 'dataset', 'model', 'parameters', 'status', 'creationTime')
+    fields = (
+        'pk',
+        'name',
+        'dataset',
+        'model',
+        'parameters',
+        'status',
+        'creationTime'
+    )
     template_name = 'Proccessing/list.html'
     context_object_name = "task_list"
     paginate_by = PER_PAGE

--- a/AssrWeb/Visual/Plotting/PlotGenerator.py
+++ b/AssrWeb/Visual/Plotting/PlotGenerator.py
@@ -83,6 +83,8 @@ class PlotGenerator():
                     G.add_edge(i, j, weight=similarity)
 
         if len(G.edges()) == 0:
+            vis = Visualization(plt.figure())
+            vis.label('Relations Graph')
             return Visualization(plt.figure())
 
         pos = nx.spring_layout(G, seed=42, k=0.5)

--- a/AssrWeb/Visual/api/visualization.py
+++ b/AssrWeb/Visual/api/visualization.py
@@ -58,20 +58,25 @@ def get_all_figures(request, task_pk):
 @require_GET
 def download_visualization(request, task_pk):
     process = get_object_or_404(Processing_model, pk=task_pk)
-    vis_name = request.GET.get('vis_name')
+    vis_name = request.GET.get('vis_name')  # From request is it combination of title and name?
+    print("REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",vis_name)
     file_format = request.GET.get('format', 'png')
 
     plot_generator = PlotGenerator(process)
     figures = plot_generator.get_all_available_figures()
 
     for vis in figures:
-        if vis.name == vis_name:
+        if vis.label is None:
+            vis.label = ""
+        vis_title = f'{vis.name}_{vis.label}'
+        print("TYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY", vis_title)
+        if vis_title == vis_name:
             file_data = vis.get_file_in_format(file_format)
             response = HttpResponse(
                 file_data,
                 content_type=f'image/{file_format}'
             )
-            response['Content-Disposition'] = 'attachment;' + f'filename="{vis_name}.{file_format}"'
+            response['Content-Disposition'] = 'attachment;' + f'filename="{vis_title}.{file_format}"'
             return response
 
     return JsonResponse({"error": "Visualization not found"}, status=404)

--- a/AssrWeb/Visual/api/visualization.py
+++ b/AssrWeb/Visual/api/visualization.py
@@ -59,7 +59,6 @@ def get_all_figures(request, task_pk):
 def download_visualization(request, task_pk):
     process = get_object_or_404(Processing_model, pk=task_pk)
     vis_name = request.GET.get('vis_name')  # From request is it combination of title and name?
-    print("REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",vis_name)
     file_format = request.GET.get('format', 'png')
 
     plot_generator = PlotGenerator(process)
@@ -69,7 +68,6 @@ def download_visualization(request, task_pk):
         if vis.label is None:
             vis.label = ""
         vis_title = f'{vis.name}_{vis.label}'
-        print("TYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY", vis_title)
         if vis_title == vis_name:
             file_data = vis.get_file_in_format(file_format)
             response = HttpResponse(

--- a/AssrWeb/static/js/visualization/getFigures.js
+++ b/AssrWeb/static/js/visualization/getFigures.js
@@ -44,22 +44,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 container.innerHTML = `<div class="alert alert-danger">Ошибка: ${error.message}</div>`;
             }
         }
-        
-
-        // function groupByLabel(visualizations) {
-        //     const grouped = {};
-        //     visualizations.forEach(vis => {
-        //         const label = vis.meta.label || 'Общие';
-        //         if (!grouped[label]) {
-        //             grouped[label] = [];
-        //         }
-
-        //         if (!grouped[label].some(existing => existing.meta.name === vis.meta.name)) {
-        //             grouped[label].push(vis);
-        //         }
-        //     });
-        //     return grouped;
-        // }
 
         function render(selectedLabel, interactive) {
             container.innerHTML = '';

--- a/AssrWeb/static/js/visualization/getFigures.js
+++ b/AssrWeb/static/js/visualization/getFigures.js
@@ -46,20 +46,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         
 
-        function groupByLabel(visualizations) {
-            const grouped = {};
-            visualizations.forEach(vis => {
-                const label = vis.meta.label || 'Общие';
-                if (!grouped[label]) {
-                    grouped[label] = [];
-                }
+        // function groupByLabel(visualizations) {
+        //     const grouped = {};
+        //     visualizations.forEach(vis => {
+        //         const label = vis.meta.label || 'Общие';
+        //         if (!grouped[label]) {
+        //             grouped[label] = [];
+        //         }
 
-                if (!grouped[label].some(existing => existing.meta.name === vis.meta.name)) {
-                    grouped[label].push(vis);
-                }
-            });
-            return grouped;
-        }
+        //         if (!grouped[label].some(existing => existing.meta.name === vis.meta.name)) {
+        //             grouped[label].push(vis);
+        //         }
+        //     });
+        //     return grouped;
+        // }
 
         function render(selectedLabel, interactive) {
             container.innerHTML = '';
@@ -89,13 +89,13 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             if (filteredDistributions.length > 0) {
-                const grouped = groupByLabel(filteredDistributions);
-                Object.keys(grouped).forEach(label => {
+                const grouped = groupByName(filteredDistributions);
+                Object.keys(grouped).forEach(name => {
                     html += `
                         <div class="col-12 mb-4">
-                            <h4>${label}</h4>
+                            <h4>${name}</h4>
                             <div class="row">
-                                ${grouped[label].map(vis => 
+                                ${grouped[name].map(vis => 
                                     vis.meta.type === 'interactive' 
                                         ? interactiveTemplate(vis) 
                                         : staticTemplate(vis)
@@ -110,13 +110,32 @@ document.addEventListener('DOMContentLoaded', () => {
 
         function groupByLabel(visualizations) {
             const grouped = {};
+
             visualizations.forEach(vis => {
                 const label = vis.meta.label || 'Общие';
+
                 if (!grouped[label]) {
                     grouped[label] = [];
                 }
                 if (!grouped[label].some(existing => existing.meta.name === vis.meta.name)) {
                     grouped[label].push(vis);
+                }
+            });
+            return grouped;
+        }
+
+        function groupByName(visualizations) {
+            const grouped = {};
+            
+
+            visualizations.forEach(vis => {
+                const name = vis.meta.name;
+
+                if (!grouped[name]) {
+                    grouped[name] = [];
+                }
+                if (!grouped[name].some(existing => existing.meta.label === vis.meta.label)) {
+                    grouped[name].push(vis);
                 }
             });
             return grouped;
@@ -140,11 +159,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             }, 0);
 
+            if (vis.meta.label == null){
+                vis.meta.label = ""
+            }
+
             return `
                 <div class="col-md-6 mb-4">
                     <div class="card h-100">
                         <div class="card-header d-flex justify-content-between align-items-center">
-                            <span class="card-header-text">${vis.meta.name}</span>
+                            <span class="card-header-text">${vis.meta.name}_${vis.meta.label}</span>
                             <div class="dropdown">
                                 <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
                                     Скачать
@@ -163,27 +186,32 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>`;
         };
 
-        const staticTemplate = (vis) => `
-            <div class="col-md-6 mb-4">
-                <div class="card">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <span class="card-header-text">${vis.meta.name}</span>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                                Скачать
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item download-vis" data-format="png" href="#">PNG</a></li>
-                                <li><a class="dropdown-item download-vis" data-format="svg" href="#">SVG</a></li>
-                                <li><a class="dropdown-item download-vis" data-format="pdf" href="#">PDF</a></li>
-                            </ul>
+        const staticTemplate = (vis) => {
+            if (vis.meta.label == null){
+                vis.meta.label = ""
+            }
+            return `
+                <div class="col-md-6 mb-4">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span class="card-header-text">${vis.meta.name}_${vis.meta.label}</span>
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                                    Скачать
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li><a class="dropdown-item download-vis" data-format="png" href="#">PNG</a></li>
+                                    <li><a class="dropdown-item download-vis" data-format="svg" href="#">SVG</a></li>
+                                    <li><a class="dropdown-item download-vis" data-format="pdf" href="#">PDF</a></li>
+                                </ul>
+                            </div>
                         </div>
+                        <img src="data:image/png;base64,${vis.content}" 
+                            class="card-img-top" 
+                            alt="${vis.meta.name}">
                     </div>
-                    <img src="data:image/png;base64,${vis.content}" 
-                         class="card-img-top" 
-                         alt="${vis.meta.name}">
-                </div>
-            </div>`;
+                </div>`;
+        };
 
         return { load, render };
     })();

--- a/AssrWeb/templates/Proccessing/create.html
+++ b/AssrWeb/templates/Proccessing/create.html
@@ -17,6 +17,9 @@
         <h4 class="main-text">Своя модель с <a href="https://huggingface.co/">Hugging Face</a></h4>
         <hr>
         <form method="post" id="task_from">{% csrf_token %}
+            <h4 class="main-text">Дайте имя задаче:</h4>
+            {% render_field form.name id="name" class="main-text" %}
+
             <h4 class="main-text">Выберите датасет:</h4>
             {% render_field form.dataset id="dataset_id" %}
 

--- a/AssrWeb/templates/Proccessing/list.html
+++ b/AssrWeb/templates/Proccessing/list.html
@@ -15,6 +15,7 @@
                 <a href="{% url 'processing:view' task.pk %}" class="main-text unlink darken-on-hover p-0">
                     <div class="row px-5">
                         <div class="col">Номер</div>
+                        <div class="col">Название</div>
                         <div class="col">Датасет</div>
                         <div class="col">Модель</div>
                         <div class="col">Статус</div>
@@ -24,6 +25,7 @@
                 <hr>
                 <div class="row px-5 main-text mini-text">
                     <div class="col"> <a href="{% url 'processing:view' task.pk %}"> {{task.pk}} </a> </div>
+                    <div class="col"> <a href="{% url 'processing:view' task.pk %}"> {{task.name}} </a> </div>
                     <div class="col"><a href="{% url 'dataset:view_dataset' task.dataset.id %}">{{ task.dataset.id }}</a></div>
                     <div class="col">{{ task.model }}</div>
                     <div class="col">{{ task.get_status_display }}</div>

--- a/AssrWeb/templates/Proccessing/results.html
+++ b/AssrWeb/templates/Proccessing/results.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.jsdelivr.net/npm/mpld3@0.5.10/dist/mpld3.min.js"></script>
     <script src="{% static 'js/visualization/getFigures.js' %}"></script>
 {% endblock %}
+<h1>Задача: {{process.name}}<h1>
 <h1>Обработка датасета <a href="{% url 'dataset:view_dataset' process.dataset.pk %}" > {{process.dataset.metadata.name}}</a> </h1>
 <div class="status main-text">Задача создана: {{process.creationTime}}
 <div class="status main-text">Статус задачи: 


### PR DESCRIPTION
Как обсуждалось поменял сортировку графиков (для этого поменял и названия графиков aka labels)
1. Исправил логику скачки графика ранее на скачку были доступны только первые N графиков с уникальными названиями.
2. Мало исправление в JS
3. Processing_model обладает еще одним новым полем name (его пользователь выбирает сам).

## Summary by Sourcery

Add a user-defined name field to processing tasks and update visualization grouping and download logic.

New Features:
- Allow users to assign a name to each processing task.

Bug Fixes:
- Enable downloading of all generated visualizations by using a unique combined name (task name + label).

Enhancements:
- Group visualizations by task name instead of label on the results page.
- Display visualizations with a title combining the task name and visualization label.
- Update task list and results pages to show the new task name.

Chores:
- Update forms, models, and views to incorporate the new task name field.
- Handle potential null labels in visualization metadata when generating titles.
- Assign a default label to the relations graph visualization when it contains no data.